### PR TITLE
HQT-1 Feature: 스크린간 데이터 전송 기능(캘린더 페이지(선택된 날짜) → 글 작성페이지)

### DIFF
--- a/app/src/main/java/com/codingslaved/diary/ui/Navigation.kt
+++ b/app/src/main/java/com/codingslaved/diary/ui/Navigation.kt
@@ -1,12 +1,14 @@
 package com.codingslaved.diary.ui
 
 import androidx.compose.runtime.Composable
+import androidx.lifecycle.viewmodel.compose.viewModel
 import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
 import androidx.navigation.compose.rememberNavController
 import com.codingslaved.diary.ui.screens.home.HomeScreen
 import com.codingslaved.diary.ui.screens.calendar.CalendarScreen
 import com.codingslaved.diary.view.WritingScreen
+import com.codingslaved.diary.viewmodel.SharedViewModel
 
 object Routes {
     const val HOME = "home"
@@ -17,6 +19,7 @@ object Routes {
 @Composable
 fun Navigation() {
     val navController = rememberNavController()
+    val viewModel: SharedViewModel = viewModel()
 
     NavHost(
         navController = navController,
@@ -26,10 +29,10 @@ fun Navigation() {
             HomeScreen(navController = navController)
         }
         composable(route = Routes.CALENDAR) {
-            CalendarScreen(navController = navController)
+            CalendarScreen(navController = navController, viewModel = viewModel)
         }
         composable(route = Routes.WRITING) {
-            WritingScreen()
+            WritingScreen(selectViewModel = viewModel)
         }
     }
 }

--- a/app/src/main/java/com/codingslaved/diary/ui/screens/calendar/CalendarScreen.kt
+++ b/app/src/main/java/com/codingslaved/diary/ui/screens/calendar/CalendarScreen.kt
@@ -44,6 +44,8 @@ import androidx.compose.ui.unit.*
 import androidx.navigation.NavController
 import com.codingslaved.diary.R
 import com.codingslaved.diary.ui.Routes
+import com.codingslaved.diary.viewmodel.SharedViewModel
+import java.time.LocalDate
 
 enum class Mode {
     MONTH,
@@ -65,7 +67,7 @@ fun calculateHeight(mode: Mode): Dp {
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
-fun CalendarScreen(navController: NavController) {
+fun CalendarScreen(navController: NavController, viewModel: SharedViewModel) {
     var currentMode by remember { mutableStateOf(Mode.MONTH) }
     var rawHeight by remember { mutableStateOf(calculateHeight(currentMode)) } // Dp 단위로 관리
     var isDragging by remember { mutableStateOf(false) }
@@ -147,7 +149,10 @@ fun CalendarScreen(navController: NavController) {
                     onDragEnd = { isDragging = false }
                 )
                 ScheduleContent(
-                    navController = navController,
+                    onClick = {
+                        viewModel.setData(LocalDate.now().plusMonths(5).plusDays(12))
+                        navController.navigate(Routes.WRITING)
+                    },
                     modifier = Modifier
                         .fillMaxSize()
                         .padding(
@@ -195,10 +200,10 @@ private fun Header(mode: Mode = Mode.MONTH, onChangeMode: (Mode) -> Unit = {}) {
 }
 
 @Composable
-private fun ScheduleContent(navController: NavController, modifier: Modifier = Modifier) {
+private fun ScheduleContent(onClick: () -> Unit, modifier: Modifier = Modifier) {
 
     Card (
-        onClick = {navController.navigate(Routes.WRITING)},
+        onClick = onClick,
         modifier = modifier
             .padding(
                 top = 10.dp,

--- a/app/src/main/java/com/codingslaved/diary/view/WritingScreen.kt
+++ b/app/src/main/java/com/codingslaved/diary/view/WritingScreen.kt
@@ -1,8 +1,5 @@
 package com.codingslaved.diary.view
 
-import android.os.Bundle
-import androidx.activity.ComponentActivity
-import androidx.activity.compose.setContent
 import androidx.compose.foundation.background
 import androidx.compose.foundation.focusable
 import androidx.compose.foundation.layout.Arrangement
@@ -31,6 +28,7 @@ import androidx.compose.material3.TextField
 import androidx.compose.material3.TextFieldDefaults
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.MutableState
+import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
@@ -51,15 +49,22 @@ import androidx.lifecycle.viewmodel.compose.viewModel
 import com.codingslaved.diary.viewmodel.DiaryDetails
 import com.codingslaved.diary.viewmodel.DiaryEntryViewModel
 import com.codingslaved.diary.viewmodel.DiaryProvider
+import com.codingslaved.diary.viewmodel.SharedViewModel
 import kotlinx.coroutines.launch
+import androidx.compose.runtime.getValue
+import java.time.LocalDate
 
 @Composable
 fun WritingScreen(
+    selectViewModel: SharedViewModel,
     viewModel: DiaryEntryViewModel = viewModel(factory = DiaryProvider.Factory)
 ) {
+    val date by selectViewModel.data.collectAsState(LocalDate.now())
+
     Scaffold { innerPadding ->
         Column(modifier = Modifier.padding(innerPadding)) {
             Head(Modifier.padding(innerPadding))
+            Text(text = date.toString())
             HorizontalDivider(modifier = Modifier.padding(2.dp), thickness = 2.dp)
             TextField(
                 viewModel,
@@ -173,7 +178,7 @@ fun WritingPagePreview() {
                 .padding(start = 2.dp, top = 5.dp, end = 2.dp, bottom = 5.dp),
             color = MaterialTheme.colorScheme.background
         ) {
-            WritingScreen()
+            WritingScreen(selectViewModel = SharedViewModel())
         }
     }
 }

--- a/app/src/main/java/com/codingslaved/diary/viewmodel/SharedViewModel.kt
+++ b/app/src/main/java/com/codingslaved/diary/viewmodel/SharedViewModel.kt
@@ -1,0 +1,15 @@
+package com.codingslaved.diary.viewmodel
+
+import androidx.lifecycle.ViewModel
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.asSharedFlow
+import java.time.LocalDate
+
+class SharedViewModel : ViewModel() {
+    private val _data = MutableStateFlow<LocalDate?>(null)
+    val data = _data.asSharedFlow()
+
+    fun setData(date: LocalDate) {
+        _data.value = date
+    }
+}


### PR DESCRIPTION
스크린간 데이터 전송 기능(캘린더 페이지(선택된 날짜) → 글 작성페이지)

- SharedViewModel을 추가하여 날짜 데이터를 관리하도록 구현.
- CalendarScreen에서 SharedViewModel을 사용하여 날짜 설정 기능 추가.
- WritingScreen에서 SharedViewModel을 통해 선택된 날짜를 표시하도록 수정.
- Navigation.kt에서 각 화면에 SharedViewModel을 전달하도록 변경.