### PR TITLE
HQT-6 Diary 엔티티의 date Column 타입 컨버터 개발

### DIFF
--- a/app/src/main/java/com/codingslaved/diary/data/converter/Converters.kt
+++ b/app/src/main/java/com/codingslaved/diary/data/converter/Converters.kt
@@ -1,0 +1,16 @@
+package com.codingslaved.diary.data.converter
+
+import androidx.room.TypeConverter
+import java.time.LocalDate
+
+class Converters {
+    @TypeConverter
+    fun stringToLocalDate(value: String): LocalDate {
+        return LocalDate.parse(value)
+    }
+
+    @TypeConverter
+    fun localDateToString(date: LocalDate): String {
+        return date.toString()
+    }
+}

--- a/app/src/main/java/com/codingslaved/diary/data/dao/DiaryDao.kt
+++ b/app/src/main/java/com/codingslaved/diary/data/dao/DiaryDao.kt
@@ -6,11 +6,12 @@ import androidx.room.Query
 import androidx.room.Update
 import com.codingslaved.diary.data.model.Diary
 import kotlinx.coroutines.flow.Flow
+import java.time.LocalDate
 
 @Dao
 interface DiaryDao {
-    @Query("SELECT * FROM diary WHERE date LIKE :date")
-    fun getDiary(date: String): Flow<Diary>
+    @Query("SELECT * FROM diary WHERE date = :date")
+    fun getDiary(date: LocalDate): Flow<Diary>
 
     @Insert
     suspend fun insert(diary: Diary)

--- a/app/src/main/java/com/codingslaved/diary/data/database/DiaryDatabase.kt
+++ b/app/src/main/java/com/codingslaved/diary/data/database/DiaryDatabase.kt
@@ -4,10 +4,13 @@ import android.content.Context
 import androidx.room.Database
 import androidx.room.Room
 import androidx.room.RoomDatabase
+import androidx.room.TypeConverters
+import com.codingslaved.diary.data.converter.Converters
 import com.codingslaved.diary.data.dao.DiaryDao
 import com.codingslaved.diary.data.model.Diary
 
-@Database(entities = [Diary::class], version = 1)
+@Database(entities = [Diary::class], version = 1, exportSchema = false)
+@TypeConverters(Converters::class)
 abstract class DiaryDatabase : RoomDatabase() {
     abstract fun diaryDao(): DiaryDao
 

--- a/app/src/main/java/com/codingslaved/diary/data/model/Diary.kt
+++ b/app/src/main/java/com/codingslaved/diary/data/model/Diary.kt
@@ -3,10 +3,11 @@ package com.codingslaved.diary.data.model
 import androidx.room.ColumnInfo
 import androidx.room.Entity
 import androidx.room.PrimaryKey
+import java.time.LocalDate
 
 @Entity
 data class Diary(
     @PrimaryKey val id: String,
     @ColumnInfo(name = "text", typeAffinity = ColumnInfo.TEXT) val text: String,
-    @ColumnInfo(name = "date", typeAffinity = ColumnInfo.TEXT) val date: String,
+    @ColumnInfo(name = "date", typeAffinity = ColumnInfo.TEXT) val date: LocalDate,
 )

--- a/app/src/main/java/com/codingslaved/diary/data/repository/DiaryRepository.kt
+++ b/app/src/main/java/com/codingslaved/diary/data/repository/DiaryRepository.kt
@@ -2,9 +2,10 @@ package com.codingslaved.diary.data.repository
 
 import com.codingslaved.diary.data.model.Diary
 import kotlinx.coroutines.flow.Flow
+import java.time.LocalDate
 
 interface DiaryRepository {
-    fun getDiary(date: String): Flow<Diary>
+    fun getDiary(date: LocalDate): Flow<Diary>
     suspend fun insert(diary: Diary)
     suspend fun update(diary: Diary)
 

--- a/app/src/main/java/com/codingslaved/diary/data/repository/DiaryRepositoryImpl.kt
+++ b/app/src/main/java/com/codingslaved/diary/data/repository/DiaryRepositoryImpl.kt
@@ -3,9 +3,10 @@ package com.codingslaved.diary.data.repository
 import com.codingslaved.diary.data.dao.DiaryDao
 import com.codingslaved.diary.data.model.Diary
 import kotlinx.coroutines.flow.Flow
+import java.time.LocalDate
 
 class DiaryRepositoryImpl(private val diaryDao: DiaryDao) : DiaryRepository {
-    override fun getDiary(date: String): Flow<Diary> = diaryDao.getDiary(date)
+    override fun getDiary(date: LocalDate): Flow<Diary> = diaryDao.getDiary(date)
 
     override suspend fun insert(diary: Diary) = diaryDao.insert(diary)
 

--- a/app/src/main/java/com/codingslaved/diary/view/WritingScreen.kt
+++ b/app/src/main/java/com/codingslaved/diary/view/WritingScreen.kt
@@ -65,7 +65,7 @@ fun WritingScreen(
     var isFirst by remember { mutableStateOf(true) }
 
     if (date != null) {
-        val diary = viewModel.getDiaryByDate(date.toString()).collectAsState(initial = null)
+        val diary = viewModel.getDiaryByDate(date!!).collectAsState(initial = null)
         diary.value?.let {
             if (isFirst) {
                 viewModel.updateUiState(
@@ -104,10 +104,10 @@ fun Head(viewModel: DiaryEntryViewModel, date: LocalDate?, modifier: Modifier = 
 
     val today = if (date == null) {
         val now = LocalDate.now()
-        viewModel.updateUiState(diaryUiState.diaryDetails.copy(date = now.toString()))
+        viewModel.updateUiState(diaryUiState.diaryDetails.copy(date = now))
         "${now.year}년 ${now.monthValue}월 ${now.dayOfMonth}일"
     } else {
-        viewModel.updateUiState(diaryUiState.diaryDetails.copy(date = date.toString()))
+        viewModel.updateUiState(diaryUiState.diaryDetails.copy(date = date))
         "${date.year}년 ${date.monthValue}월 ${date.dayOfMonth}일"
     }
 

--- a/app/src/main/java/com/codingslaved/diary/view/calendar/CalendarScreen.kt
+++ b/app/src/main/java/com/codingslaved/diary/view/calendar/CalendarScreen.kt
@@ -222,10 +222,10 @@ private fun ScheduleContent(
     modifier: Modifier = Modifier
 ) {
     val diaryEntryViewModel: DiaryEntryViewModel = viewModel(factory = DiaryProvider.Factory)
-    val diaryEntry by diaryEntryViewModel.getDiaryByDate(selectedDate.toString()).collectAsState(initial = null)
+    val diaryEntry by diaryEntryViewModel.getDiaryByDate(selectedDate).collectAsState(initial = null)
 
     LaunchedEffect(selectedDate) {
-        diaryEntryViewModel.getDiaryByDate(selectedDate.toString())
+        diaryEntryViewModel.getDiaryByDate(selectedDate)
     }
 
     Card (

--- a/app/src/main/java/com/codingslaved/diary/viewmodel/DiaryEntryViewModel.kt
+++ b/app/src/main/java/com/codingslaved/diary/viewmodel/DiaryEntryViewModel.kt
@@ -6,6 +6,7 @@ import androidx.compose.runtime.setValue
 import androidx.lifecycle.ViewModel
 import com.codingslaved.diary.data.model.Diary
 import com.codingslaved.diary.data.repository.DiaryRepository
+import java.time.LocalDate
 
 class DiaryEntryViewModel(private val diaryRepository: DiaryRepository) : ViewModel() {
     var diaryUiState by mutableStateOf(DiaryUiState())
@@ -18,11 +19,11 @@ class DiaryEntryViewModel(private val diaryRepository: DiaryRepository) : ViewMo
 
     private fun validateInput(uiState: DiaryDetails = diaryUiState.diaryDetails): Boolean {
         return with(uiState) {
-            id.isNotBlank() && text.isNotBlank() && date.isNotBlank()
+            id.isNotBlank() && text.isNotBlank()
         }
     }
 
-    fun getDiaryByDate(date: String) = diaryRepository.getDiary(date)
+    fun getDiaryByDate(date: LocalDate) = diaryRepository.getDiary(date)
 
     suspend fun saveDiary() {
         if (validateInput()) {
@@ -45,7 +46,7 @@ data class DiaryUiState(
 data class DiaryDetails(
     val id: String = "",
     val text: String = "",
-    val date: String = "",
+    val date: LocalDate = LocalDate.now(),
 )
 
 fun DiaryDetails.toItem(): Diary = Diary(


### PR DESCRIPTION
### Goal
SQLite는 datetime을 제공하지 않는다. 그래서 date의 타입을 String으로 정했다. ISO8601 string으로 변환은 지원해주지만 우리는 날짜만 사용하기를 원하기 때문에 맞지 않다. 따라서 자체 타입 변환기능을 구현한다. 사실 Room에서 제공해서 그거 쓰면 된다. 

### Detail

- 정확한 데이터 타입 관리를 위해 Diary.date 의 타입을 LocalDate 로 변경
- Room database 의 Type Convert 기능 활용을 위해 Converters 추가
- DiaryRepository, DiaryDao 의 getDiary 함수 타입을 LocalDate 타입을 사용하게 수정
- WritingScreen, CalendarScreen, DiaryEntryViewModel 에서 date 관련 로직을 LocalDate 를 사용하게 수정